### PR TITLE
Added default_outcome request variable

### DIFF
--- a/spec/outbound_spec.coffee
+++ b/spec/outbound_spec.coffee
@@ -103,6 +103,15 @@ describe 'Outbound Request', ->
 
 
 
+describe 'Outbound Validate', ->
+
+  it 'should require valid default_outcome', ->
+    assert.equal integration.validate(default_outcome: 'donkey'), 'default outcome must be "success", "failure" or "error"'
+
+  it 'should allow valid default_outcome', ->
+    assert.isUndefined integration.validate(default_outcome: 'success')
+
+
 describe 'Outbound Response', ->
 
   it 'should default outcome to "error"', (done) ->
@@ -112,6 +121,15 @@ describe 'Outbound Response', ->
     integration.handle variables(), (err, event) ->
       return done(err) if err?
       assert.equal event.outcome, 'error'
+      done()
+
+  it 'should default outcome to specified default', (done) ->
+    @service = nock('http://externalservice')
+      .post '/'
+      .reply(200, id: 42)
+    integration.handle variables(default_outcome: 'success'), (err, event) ->
+      return done(err) if err?
+      assert.equal event.outcome, 'success'
       done()
 
   it 'should default outcome to an error message', (done) ->

--- a/src/outbound.coffee
+++ b/src/outbound.coffee
@@ -22,7 +22,7 @@ handle = (vars, callback) ->
 
     if !parsed.outcome?
       parsed =
-        outcome: 'error'
+        outcome: vars.default_outcome or 'error'
         reason: parsed.reason or 'Unrecognized response'
 
     callback null, parsed
@@ -37,6 +37,7 @@ requestVariables = ->
   [
     { name: 'url', description: 'Server URL', type: 'string', required: true }
     { name: 'method', description: 'HTTP method (GET or POST)', type: 'string', required: true }
+    { name: 'default_outcome', description: 'Outcome to return if recipient returns none (success, failure, error). If not specified, "error" will be used.', type: 'string' }
     { name: 'lead.*', type: 'wildcard', required: true }
   ]
 
@@ -153,6 +154,12 @@ req = (vars) ->
     body: content
 
 
+validate = (vars) ->
+  if vars.default_outcome? and !vars.default_outcome.match(/success|failure|error/)
+    'default outcome must be "success", "failure" or "error"'
+
+
+
 #
 # Exports ----------------------------------------------------------------
 #
@@ -160,7 +167,7 @@ req = (vars) ->
 module.exports =
   name: 'Generic POST'
   handle: handle
+  validate: validate
   requestVariables: requestVariables
   responseVariables: responseVariables
-
 


### PR DESCRIPTION
Allows user to customize behavior when upstream server fails to return an "outcome" value.

:cherries:
@cgrayson, pretty please