### PR TITLE
Require Content-Length to match body length

### DIFF
--- a/spec/inbound_spec.coffee
+++ b/spec/inbound_spec.coffee
@@ -37,6 +37,15 @@ describe 'Inbound Request', ->
       assert.equal e.body, 'MIME type in Content-Type header is not supported. Use only application/x-www-form-urlencoded, application/json, application/xml, text/xml.'
       assert.deepEqual e.headers, 'Content-Type': 'text/plain'
 
+  it 'should require content length to match body', ->
+    try
+      integration.request(method: 'post', uri: '/flows/12345/sources/12345/submit', headers: { 'Content-Length': '0', 'Content-Type': 'application/json'}, body: 'first_name=Joe&callcenter.additional_services=script+writing')
+      assert.fail("expected an error to be thrown when content does not match body length")
+    catch e
+      assert.equal e.status, 400
+      assert.equal e.body, 'Declared Content-Length header does not match actual body length'
+      assert.deepEqual e.headers, 'Content-Type': 'text/plain'
+
   it 'should parse posted form url encoded body', ->
     body = 'first_name=Joe&last_name=Blow&email=jblow@test.com&phone_1=5127891111'
     assertParses 'application/x-www-form-urlencoded', body

--- a/src/inbound.coffee
+++ b/src/inbound.coffee
@@ -70,6 +70,10 @@ request = (req) ->
       unless supportedMimeTypeLookup[mimeType]?
         throw new HttpError(406, {'Content-Type': 'text/plain'}, "MIME type in Content-Type header is not supported. Use only #{supportedMimeTypes.join(', ')}.")
 
+      # ensure content length matches body length
+      if req.headers['Content-Length'] != req.body.length
+        throw new HttpError(400, {'Content-Type': 'text/plain'}, 'Declared Content-Length header does not match actual body length')
+
       # parse request body according the the mime type
       parsed = mimecontent(req.body, mimeType)
 


### PR DESCRIPTION
Resolves #18 (as well as handles other instances where there is mismatch between content-length headers and body)