### PR TITLE
Add timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
   - 0.10
+  - 4
 sudo: false

--- a/package.json
+++ b/package.json
@@ -24,18 +24,15 @@
   "dependencies": {
     "dotaccess": "^1.0.5",
     "flat": "^1.3.0",
-    "leadconduit-fields": "^1.0.0",
-    "leadconduit-integration": "0.0.1",
+    "leadconduit-integration": "^0.1.0",
     "lodash": "^2.4.1",
     "mime-content": ">=0.0.6",
     "mimeparse": "*",
-    "request": "^2.51.0",
     "xmlbuilder": "*"
   },
   "devDependencies": {
     "chai": ">= 1.9.0",
     "coffee-script": ">= 1.7.0",
-    "mocha": ">= 1.17.0",
-    "nock": "^0.52.0"
+    "mocha": ">= 1.17.0"
   }
 }

--- a/spec/helper.coffee
+++ b/spec/helper.coffee
@@ -1,26 +1,26 @@
-flat = require 'flat'
-dotaccess = require 'dotaccess'
-fields = require 'leadconduit-fields'
-
-
-variables = (vars={}) ->
-  flatVars = flat.flatten(vars)
-
-  defaultVars =
-    url: 'http://externalservice'
-    method: 'post'
-    lead:
-      first_name: 'Joe'
-      last_name: 'Blow'
-      email: 'JBLOW@TEST.COM'
-      phone_1: '512-789-1111'
-
-  for key, value of flatVars
-    dotaccess.set(defaultVars, key, value, true)
-
-  defaultVars.lead = fields.buildLeadVars(defaultVars.lead)
-  defaultVars
+dotaccess = require('dotaccess')
+flat = require('flat')
+types = require('leadconduit-integration').test.types
 
 
 module.exports =
-  variables: variables
+  variables: (requestVariables) ->
+    parse = types.parser(requestVariables)
+
+    (override={}) ->
+
+      override = flat.flatten(override, safe: true)
+
+      vars =
+        url: 'http://externalservice'
+        method: 'post'
+        lead:
+          first_name: 'Joe'
+          last_name: 'Blow'
+          email: 'JBLOW@TEST.COM'
+          phone_1: '512-789-1111'
+
+      for key, value of override
+        dotaccess.set(vars, key, value, true)
+
+      parse(vars)

--- a/spec/inbound_spec.coffee
+++ b/spec/inbound_spec.coffee
@@ -3,7 +3,6 @@ assert = require('chai').assert
 url = require('url')
 querystring = require('querystring')
 integration = require('../src/inbound')
-variables = require('./helper').variables
 
 
 describe 'Inbound Request', ->
@@ -11,14 +10,18 @@ describe 'Inbound Request', ->
   it 'should not allow head', ->
     assertMethodNotAllowed('head')
 
+
   it 'should not allow put', ->
     assertMethodNotAllowed('put')
+
 
   it 'should not allow delete', ->
     assertMethodNotAllowed('delete')
 
+
   it 'should not allow patch', ->
     assertMethodNotAllowed('patch')
+
 
   it 'should require content type header for posts with content', ->
     try
@@ -29,6 +32,7 @@ describe 'Inbound Request', ->
       assert.equal e.body, 'Content-Type header is required'
       assert.deepEqual e.headers, 'Content-Type': 'text/plain'
 
+
   it 'should require supported mimetype', ->
     try
       integration.request(method: 'post', uri: '/flows/12345/sources/12345/submit', headers: { 'Content-Length': '1', 'Content-Type': 'Monkies' })
@@ -37,6 +41,7 @@ describe 'Inbound Request', ->
       assert.equal e.status, 406
       assert.equal e.body, 'MIME type in Content-Type header is not supported. Use only application/x-www-form-urlencoded, application/json, application/xml, text/xml.'
       assert.deepEqual e.headers, 'Content-Type': 'text/plain'
+
 
   it 'should throw an error when it cant parse xml', ->
     body = 'xxTrustedFormCertUrl=https://cert.trustedform.com/testtoken'
@@ -47,6 +52,7 @@ describe 'Inbound Request', ->
       assert.equal e.status, 400
       assert.equal e.body, 'Body does not contain XML or XML is unparseable -- Error: Non-whitespace before first tag. Line: 0 Column: 1 Char: x.'
       assert.deepEqual e.headers, 'Content-Type': 'text/plain'
+
 
    it 'should not parse empty body', ->
       req =
@@ -65,6 +71,7 @@ describe 'Inbound Request', ->
     body = 'first_name=Joe&last_name=Blow&email=jblow@test.com&phone_1=5127891111'
     assertParses 'application/x-www-form-urlencoded', body
 
+
   it 'should parse nested form url encoded body', ->
     body = 'first_name=Joe&callcenter.additional_services=script+writing'
     assertParses 'application/x-www-form-urlencoded', body,
@@ -72,13 +79,16 @@ describe 'Inbound Request', ->
       callcenter:
         additional_services: 'script writing'
 
+
   it 'should parse xxTrustedFormCertUrl from request body', ->
     body = 'xxTrustedFormCertUrl=https://cert.trustedform.com/testtoken'
     assertParses 'application/x-www-form-urlencoded', body, trustedform_cert_url: 'https://cert.trustedform.com/testtoken'
 
+
   it 'should parse xxTrustedFormCertUrl case insensitively', ->
     body = 'XXTRUSTEDFORMCERTURL=https://cert.trustedform.com/testtoken'
     assertParses 'application/x-www-form-urlencoded', body, trustedform_cert_url: 'https://cert.trustedform.com/testtoken'
+
 
   it 'should parse query string on POST', ->
     body = 'param1=val1'
@@ -93,6 +103,7 @@ describe 'Inbound Request', ->
     result = integration.request(req)
     assert.deepEqual result, first_name: 'Joe', last_name: 'Blow', phone_1: '5127891111', param1: 'val1'
 
+
   it 'should parse xxTrustedFormCertUrl from query string', ->
     req =
       method: 'GET'
@@ -101,9 +112,11 @@ describe 'Inbound Request', ->
     result = integration.request(req)
     assert.deepEqual result, trustedform_cert_url: 'https://cert.trustedform.com/testtoken'
 
+
   it 'should parse posted json body', ->
     body = '{"first_name":"Joe","last_name":"Blow","email":"jblow@test.com","phone_1":"5127891111"}'
     assertParses 'application/json', body
+
 
   it 'should parse text xml', ->
     body = '''
@@ -116,6 +129,7 @@ describe 'Inbound Request', ->
            '''
 
     assertParses 'text/xml', body
+
 
   it 'should parse posted application xml', ->
     body = '''
@@ -130,11 +144,13 @@ describe 'Inbound Request', ->
     assertParses 'application/xml', body
 
 
+
 describe 'Inbound Params', ->
 
   it 'should include wildcard', ->
     assert _.find integration.request.params(), (param) ->
       param.name == '*'
+
 
 
 describe 'Inbound examples', ->
@@ -144,10 +160,12 @@ describe 'Inbound examples', ->
     for uri in _.pluck(examples, 'uri')
       assert.equal url.parse(uri).href, '/flows/123/sources/345/submit'
 
+
   it 'should have method', ->
     examples = integration.request.examples('123', '345', {})
     for method in _.pluck(examples, 'method')
       assert method == 'GET' or method == 'POST'
+
 
   it 'should have headers', ->
     examples = integration.request.examples('123', '345', {})
@@ -155,12 +173,14 @@ describe 'Inbound examples', ->
       assert _.isPlainObject(headers)
       assert headers['Accept']
 
+
   it 'should include redir url in query string', ->
     redir = 'http://foo.com?bar=baz'
     examples = integration.request.examples('123', '345', redir_url: redir)
     for uri in _.pluck(examples, 'uri')
       query = url.parse(uri, query: true).query
       assert.equal query.redir_url, redir
+
 
   it 'should properly encode URL encoded request body', ->
     params =
@@ -171,11 +191,13 @@ describe 'Inbound examples', ->
     for example in examples
       assert.equal example.body, querystring.encode(params)
 
+
   it 'should properly encode XML request body', ->
     examples = integration.request.examples('123', '345', first_name: 'alex', email: 'alex@test.com').filter (example) ->
       example.headers['Content-Type']?.match(/xml$/)
     for example in examples
       assert.equal example.body, '<?xml version="1.0"?>\n<lead>\n  <first_name>alex</first_name>\n  <email>alex@test.com</email>\n</lead>'
+
 
   it 'should properly encode JSON request body', ->
     examples = integration.request.examples('123', '345', first_name: 'alex', email: 'alex@test.com').filter (example) ->
@@ -184,12 +206,13 @@ describe 'Inbound examples', ->
       assert.equal example.body, '{\n  "first_name": "alex",\n  "email": "alex@test.com"\n}'
 
 
+
 describe 'Inbound Response', ->
 
-  vars = variables()
-  vars.lead = { id: '123' }
-  vars.outcome = 'failure'
-  vars.reason = 'bad!'
+  vars =
+    lead: { id: '123' }
+    outcome: 'failure'
+    reason: 'bad!'
 
   it 'should respond with json', ->
     req =
@@ -206,6 +229,7 @@ describe 'Inbound Response', ->
     assert.deepEqual res.headers, 'Content-Type': 'application/json', 'Content-Length': 57
     assert.equal res.body, '{"outcome":"failure","reason":"bad!","lead":{"id":"123"}}'
 
+
   it 'should default to json', ->
     req =
       uri: '/whatever'
@@ -219,7 +243,6 @@ describe 'Inbound Response', ->
     res = integration.response(req, vars)
     assert.equal res.status, 201
     assert.deepEqual res.headers['Content-Type'],  'application/json'
-
 
 
   it 'should respond with text xml', ->
@@ -237,6 +260,7 @@ describe 'Inbound Response', ->
     assert.deepEqual res.headers, 'Content-Type': 'text/xml', 'Content-Length': 129
     assert.equal res.body, '<?xml version="1.0"?>\n<result>\n  <outcome>failure</outcome>\n  <reason>bad!</reason>\n  <lead>\n    <id>123</id>\n  </lead>\n</result>'
 
+
   it 'should respond with application xml', ->
     req =
       uri: '/whatever'
@@ -251,7 +275,6 @@ describe 'Inbound Response', ->
     assert.equal res.status, 201
     assert.deepEqual res.headers, 'Content-Type': 'application/xml', 'Content-Length': 129
     assert.equal res.body, '<?xml version="1.0"?>\n<result>\n  <outcome>failure</outcome>\n  <reason>bad!</reason>\n  <lead>\n    <id>123</id>\n  </lead>\n</result>'
-
 
 
   it 'should redirect', ->

--- a/spec/outbound_spec.coffee
+++ b/spec/outbound_spec.coffee
@@ -1,188 +1,148 @@
 assert = require('chai').assert
-nock = require('nock')
 integration = require('../src/outbound')
-variables = require('./helper').variables
+
+requestVars = integration.request.variables().concat [
+  { name: 'lead.first_name', type: 'first_name' }
+  { name: 'lead.last_name', type: 'last_name' }
+  { name: 'lead.email', type: 'email' }
+  { name: 'lead.phone_1', type: 'phone' }
+]
+
+variables = require('./helper').variables(requestVars)
+
 
 describe 'Outbound Request', ->
 
-  afterEach ->
-    @service.done() if @service?
 
-  it 'should require url variable', ->
-    vars = variables()
-    delete vars.url
-    try
-      integration.handle(vars)
-      assert.fail('expected error when url variable is missing')
-    catch e
-      assert.equal e.message, 'Cannot connect to service because URL is missing'
+  it 'should send accept header', ->
+    assert.equal integration.request(variables()).headers.Accept, 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7'
 
-  it 'should require valid url variable', ->
-    vars = variables()
-    vars.url = 'donkeykong'
-    try
-      integration.handle(vars)
-      assert.fail('expected error when url variable is invalid')
-    catch e
-      assert.equal e.message, 'Cannot connect to service because URL is invalid'
 
-  it 'should not allow head', ->
-    assertMethodNotAllowed('head')
+  it 'should encode content sent via get as querystring', ->
+    url =  integration.request(variables(method: 'get')).url
+    assert.equal url, 'http://externalservice/?first_name=Joe&last_name=Blow&email=jblow%40test.com&phone_1=5127891111'
 
-  it 'should not allow put', ->
-    assertMethodNotAllowed('put')
 
-  it 'should not allow delete', ->
-    assertMethodNotAllowed('delete')
+  it 'should merge content sent via get over querystring', ->
+    req = integration.request(variables(url: 'http://externalservice?first_name=Bobby&aff_id=123', method: 'get')).url
+    assert.equal req, 'http://externalservice/?first_name=Joe&aff_id=123&last_name=Blow&email=jblow%40test.com&phone_1=5127891111'
 
-  it 'should not allow patch', ->
-    assertMethodNotAllowed('patch')
 
-  it 'should send accept header', (done) ->
-    @service = nock('http://externalservice')
-      .matchHeader('accept', 'application/json;q=0.9,text/xml;q=0.8,application/xml;q=0.7')
-      .post('/')
-      .reply(200, {})
-    integration.handle variables(), done
+  it 'should handle null variable', ->
+    url = integration.request(variables(lead: { first_name: null }, method: 'get')).url
+    assert.equal url, 'http://externalservice/?first_name=&last_name=Blow&email=jblow%40test.com&phone_1=5127891111'
 
-  it 'should encode content sent via get as querystring', (done) ->
-    @service = nock('http://externalservice')
-      .get('/?first_name=Joe&last_name=Blow&email=jblow%40test.com&phone_1=5127891111')
-      .reply(200, {})
-    integration.handle variables(method: 'get'), done
 
-  it 'should merge content sent via get over querystring', (done) ->
-    @service = nock('http://externalservice')
-      .get('/?first_name=Joe&aff_id=123&last_name=Blow&email=jblow%40test.com&phone_1=5127891111')
-      .reply(200, {})
-    integration.handle variables(url: 'http://externalservice?first_name=Bobby&aff_id=123', method: 'get'), done
+  it 'should handle undefined variable', ->
+    url = integration.request(variables(lead: { first_name: undefined }, method: 'get')).url
+    assert.equal url, 'http://externalservice/?last_name=Blow&email=jblow%40test.com&phone_1=5127891111'
 
-  it 'should handle null variable', (done) ->
-    @service = nock('http://externalservice')
-      .get('/?first_name=&last_name=Blow&email=jblow%40test.com&phone_1=5127891111')
-      .reply(200, {})
-    integration.handle variables(lead: { first_name: null }, method: 'get'), done
 
-  it 'should handle undefined variable', (done) ->
-    @service = nock('http://externalservice')
-      .get('/?last_name=Blow&email=jblow%40test.com&phone_1=5127891111')
-      .reply(200, {})
-    integration.handle variables(lead: { first_name: undefined }, method: 'get'), done
+  it 'should encode content sent as post', ->
+    body = integration.request(variables()).body
+    assert.equal body, 'first_name=Joe&last_name=Blow&email=jblow%40test.com&phone_1=5127891111'
 
-  it 'should encode content sent as post', (done) ->
-    @service = nock('http://externalservice')
-      .post '/', 'first_name=Joe&last_name=Blow&email=jblow%40test.com&phone_1=5127891111'
-      .reply(200, {})
-    integration.handle variables(), done
 
-  it 'should set content length of post', (done) ->
-    @service = nock('http://externalservice')
-      .matchHeader('content-length', 71)
-      .post '/'
-      .reply(200, {})
-    integration.handle variables(), done
+  it 'should set content length of post', ->
+    assert.equal integration.request(variables()).headers['Content-Length'], 71
 
-  it 'should set content type of post', (done) ->
-    @service = nock('http://externalservice')
-      .matchHeader('content-type', 'application/x-www-form-urlencoded')
-      .post '/'
-      .reply(200, {})
-    integration.handle variables(), done
 
-  it 'should handle dot notation vars', (done) ->
-    @service = nock('http://externalservice')
-      .get('/?deeply.nested.var=Hola')
-      .reply(200, {})
-    integration.handle url: 'http://externalservice', method: 'get', lead: { 'deeply.nested.var': 'Hola' }, done
+  it 'should set content type of post', ->
+    assert.equal integration.request(variables()).headers['Content-Type'], 'application/x-www-form-urlencoded'
 
-  it 'should handle deeply nested vars', (done) ->
-    @service = nock('http://externalservice')
-      .get('/?deeply.nested.var=Hola')
-      .reply(200, {})
-    integration.handle url: 'http://externalservice', method: 'get', lead: { deeply: { nested: { var: 'Hola' } } }, done
+
+  it 'should handle dot notation vars', ->
+    url = integration.request(url: 'http://externalservice', method: 'get', lead: { 'deeply.nested.var': 'Hola' }).url
+    assert.equal url, 'http://externalservice/?deeply.nested.var=Hola'
+
+
+  it 'should handle deeply nested vars', ->
+    url = integration.request(url: 'http://externalservice', method: 'get', lead: { deeply: { nested: { var: 'Hola' } } }).url
+    assert.equal url, 'http://externalservice/?deeply.nested.var=Hola'
 
 
 
 describe 'Outbound Validate', ->
 
   it 'should require valid default_outcome', ->
-    assert.equal integration.validate(default_outcome: 'donkey'), 'default outcome must be "success", "failure" or "error"'
+    vars = variables(default_outcome: 'donkey')
+    assert.equal integration.validate(vars), 'default outcome must be "success", "failure" or "error"'
+
 
   it 'should allow valid default_outcome', ->
-    assert.isUndefined integration.validate(default_outcome: 'success')
+    assert.isUndefined integration.validate(variables(default_outcome: 'success'))
+
+
+  it 'should require url variable', ->
+    vars = variables()
+    delete vars.url
+    assert.equal integration.validate(vars), 'URL is required'
+
+
+  it 'should require valid url variable', ->
+    vars = variables()
+    vars.url = 'donkeykong'
+    assert.equal integration.validate(vars), 'URL must be valid'
+
+
+  it 'should not allow head', ->
+    assertMethodNotAllowed('head')
+
+
+  it 'should not allow put', ->
+    assertMethodNotAllowed('put')
+
+
+  it 'should not allow delete', ->
+    assertMethodNotAllowed('delete')
+
+
+  it 'should not allow patch', ->
+    assertMethodNotAllowed('patch')
+
+
 
 
 describe 'Outbound Response', ->
 
-  it 'should default outcome to "error"', (done) ->
-    @service = nock('http://externalservice')
-      .post '/'
-      .reply(200, id: 42)
-    integration.handle variables(), (err, event) ->
-      return done(err) if err?
-      assert.equal event.outcome, 'error'
-      done()
+  vars = null
+  req = null
+  res = null
 
-  it 'should default outcome to specified default', (done) ->
-    @service = nock('http://externalservice')
-      .post '/'
-      .reply(200, id: 42)
-    integration.handle variables(default_outcome: 'success'), (err, event) ->
-      return done(err) if err?
-      assert.equal event.outcome, 'success'
-      done()
-
-  it 'should default outcome to an error message', (done) ->
-    @service = nock('http://externalservice')
-      .post '/'
-      .reply(200, id: 42)
-    integration.handle variables(), (err, event) ->
-      return done(err) if err?
-      assert.equal event.reason, 'Unrecognized response'
-      done()
-
-  it 'should preserve existing reason even if outcome defaults to "error"', (done) ->
-    @service = nock('http://externalservice')
-      .post '/'
-      .reply(200, id: 42, reason: 'Big bada boom')
-    integration.handle variables(), (err, event) ->
-      return done(err) if err?
-      assert.equal event.outcome, 'error'
-      assert.equal event.reason, 'Big bada boom'
-      done()
+  beforeEach ->
+    vars = variables()
+    res =
+      status: 200
+      headers:
+        'Content-Type': 'application/json'
+      body: '{"id":42}'
+    req = integration.request(vars)
 
 
-  it 'should parse XML response', (done) ->
-    @service = nock('http://externalservice')
-      .post '/'
-      .reply(200, xmlBody(), 'Content-Type': 'text/xml')
-    integration.handle variables(), (err, event) ->
-      return done(err) if err?
-      expected =
-        outcome: 'success'
-        reason: ''
-        lead:
-          id: '1234'
-          last_name: 'Blow'
-          email: 'jblow@test.com'
-          phone_1: '5127891111'
-      assert.deepEqual event, expected
-      done()
+  it 'should default outcome to "error"', ->
+    event = integration.response(vars, req, res)
+    assert.equal event.outcome, 'error'
+    assert.equal event.reason, 'Unrecognized response'
 
-  it 'should handle poorly formed XML response', (done) ->
-    # uses sample invalid XML from customer
-    @service = nock('http://externalservice')
-    .post '/'
-    .reply(200, '<status>Error</status><reason>Please send in the mg_site_id and mg_cid as part of your request. Request Parameter = mg_site_id</reason>', 'Content-Type': 'text/xml')
-    integration.handle variables(), (err, event) ->
-      return done(err) if err?
-      expected =
-        outcome: 'error'
-        reason: 'Unrecognized response'
-      assert.deepEqual event, expected
-      done()
 
-  it 'should parse JSON response', (done) ->
+  it 'should default outcome to specified default', ->
+    vars = variables(default_outcome: 'success')
+    req = integration.request(vars)
+    event = integration.response(vars, req, res)
+    assert.equal event.outcome, 'success'
+
+
+  it 'should preserve existing reason even if outcome defaults to "error"', ->
+    res.body = '{"id":42,"reason": "Big bada boom"}'
+    event = integration.response(vars, req, res)
+    assert.equal event.outcome, 'error'
+    assert.equal event.reason, 'Big bada boom'
+
+
+  it 'should parse XML response', ->
+    res.headers['Content-Type'] = 'text/xml'
+    res.body = xmlBody()
+    event = integration.response(vars, req, res)
     expected =
       outcome: 'success'
       reason: ''
@@ -191,22 +151,38 @@ describe 'Outbound Response', ->
         last_name: 'Blow'
         email: 'jblow@test.com'
         phone_1: '5127891111'
-    @service = nock('http://externalservice')
-      .post '/'
-      .reply(200, expected)
-    integration.handle variables(), (err, event) ->
-      return done(err) if err?
-      assert.deepEqual event, expected
-      done()
+    assert.deepEqual event, expected
+
+
+  it 'should handle poorly formed XML response', ->
+    # uses sample invalid XML from customer
+    res.headers['Content-Type'] = 'text/xml'
+    res.body = '<status>Error</status><reason>Please send in the mg_site_id and mg_cid as part of your request. Request Parameter = mg_site_id</reason>'
+    event = integration.response(vars, req, res)
+    assert.deepEqual event, outcome: 'error', reason: 'Unrecognized response'
+
+
+  it 'should parse JSON response', ->
+    expected =
+      outcome: 'success'
+      reason: ''
+      lead:
+        id: '1234'
+        last_name: 'Blow'
+        email: 'jblow@test.com'
+        phone_1: '5127891111'
+    res.body = JSON.stringify(expected)
+    event = integration.response(vars, req, res)
+    assert.deepEqual event, expected
+
+
 
 assertMethodNotAllowed = (method) ->
   vars = variables()
   vars.method = method
   try
-    integration.handle(vars)
-    assert.fail('expected integration to throw an error')
-  catch e
-    assert.equal e.message, "Unsupported HTTP method #{method.toUpperCase()}. Use GET or POST."
+    assert.equal integration.validate(vars), "Unsupported HTTP method #{method.toUpperCase()}. Use GET or POST."
+
 
 xmlBody = ->
   '''

--- a/src/inbound.coffee
+++ b/src/inbound.coffee
@@ -3,7 +3,6 @@ mimecontent = require('mime-content')
 mimeparse = require('mimeparse')
 querystring = require('querystring')
 xmlbuilder = require('xmlbuilder')
-fields = require('leadconduit-fields')
 flat = require('flat')
 url = require('url')
 HttpError = require('leadconduit-integration').HttpError


### PR DESCRIPTION
This PR adds support for setting a user-specified timeout. The `timeout_in_milliseconds` request variable is provided so the user can lower the default (360 seconds) all the way down to 10ms.

Also, this integration now uses the `leadconduit-integration` helper for parsing primitives into richly typed objects in order to simulate values passed from LeadConduit to the outbound integration for testing purposes. The `leadconduit-fields` module's `buildLeadVars` function is no longer necessary.



