### PR TITLE
add verbose inbound

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,8 @@
+inbound = require('./lib/inbound');
 module.exports = {
   name: 'LeadConduit',
-  inbound: require('./lib/inbound'),
+  inbound: inbound,
+  'inbound.inbound': inbound,
+  'inbound.verbose': require('./lib/verbose'),
   outbound: require('./lib/outbound')
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "devDependencies": {
     "chai": ">= 1.9.0",
     "coffee-script": ">= 1.7.0",
+    "leadconduit-types": "^4.8.2",
     "mocha": ">= 1.17.0"
   }
 }

--- a/spec/verbose_spec.coffee
+++ b/spec/verbose_spec.coffee
@@ -1,5 +1,6 @@
 assert = require('chai').assert
 integration = require('../src/verbose')
+types = require('leadconduit-types')
 
 describe 'Inbound Verbose Response', ->
 
@@ -57,4 +58,29 @@ describe 'Inbound Verbose Response', ->
         'Content-Type': 'application/json'
         'Content-Length': 42
       body: '{"outcome":"success","lead":{"id":"1234"}}'
+    assert.deepEqual integration.response(req, vars), expected
+
+  it 'should respond correctly with rich appended fields', ->
+    req =
+      uri: 'http://example.com'
+      headers:
+        'Accept': 'application/xml'
+    vars =
+      outcome: 'success'
+      lead:
+        id: '1234'
+      appended:
+        briteverify:
+          email:
+            status: 'valid'
+            disposable: types.boolean.parse('false')
+            role_address: types.boolean.parse('false')
+            outcome: 'success'
+            billable: types.number.parse('1')
+    expected =
+      status: 201
+      headers:
+        'Content-Type': 'application/xml'
+        'Content-Length': 390
+      body: '<?xml version=\"1.0\"?>\n<result>\n  <appended>\n    <briteverify>\n      <email>\n        <status>valid</status>\n        <disposable>false</disposable>\n        <role_address>false</role_address>\n        <outcome>success</outcome>\n        <billable>1</billable>\n      </email>\n    </briteverify>\n  </appended>\n  <outcome>success</outcome>\n  <reason/>\n  <lead>\n    <id>1234</id>\n  </lead>\n</result>'
     assert.deepEqual integration.response(req, vars), expected

--- a/spec/verbose_spec.coffee
+++ b/spec/verbose_spec.coffee
@@ -1,0 +1,60 @@
+assert = require('chai').assert
+integration = require('../src/verbose')
+
+describe 'Inbound Verbose Response', ->
+
+  before ->
+    @vars =
+      outcome: 'success'
+      lead:
+        id: '1234'
+      appended:
+        briteverify:
+          email:
+            status: 'valid'
+            disposable: 'false'
+            role_address: 'false'
+            outcome: 'success'
+
+  it 'should set appended fields correctly in JSON response', ->
+    req =
+      uri: 'http://example.com'
+      headers:
+        'Accept': 'application/json'
+    expected =
+      status: 201
+      headers:
+        'Content-Type': 'application/json'
+        'Content-Length': 162
+      body: '{"appended":{"briteverify":{"email":{"status":"valid","disposable":"false","role_address":"false","outcome":"success"}}},"outcome":"success","lead":{"id":"1234"}}'
+    assert.deepEqual integration.response(req, @vars), expected
+
+  it 'should set appended fields correctly in XML response', ->
+    req =
+      uri: 'http://example.com'
+      headers:
+        'Accept': 'application/xml'
+    expected =
+      status: 201
+      headers:
+        'Content-Type': 'application/xml'
+        'Content-Length': 359
+      body: '<?xml version=\"1.0\"?>\n<result>\n  <appended>\n    <briteverify>\n      <email>\n        <status>valid</status>\n        <disposable>false</disposable>\n        <role_address>false</role_address>\n        <outcome>success</outcome>\n      </email>\n    </briteverify>\n  </appended>\n  <outcome>success</outcome>\n  <reason/>\n  <lead>\n    <id>1234</id>\n  </lead>\n</result>'
+    assert.deepEqual integration.response(req, @vars), expected
+
+  it 'should respond correctly when no fields are appended', ->
+    req =
+      uri: 'http://example.com'
+      headers:
+        'Accept': 'application/json'
+    vars =
+      outcome: 'success'
+      lead:
+        id: '1234'
+    expected =
+      status: 201
+      headers:
+        'Content-Type': 'application/json'
+        'Content-Length': 42
+      body: '{"outcome":"success","lead":{"id":"1234"}}'
+    assert.deepEqual integration.response(req, vars), expected

--- a/src/inbound.coffee
+++ b/src/inbound.coffee
@@ -197,7 +197,7 @@ response = (req, vars, fieldIds = ['outcome', 'reason', 'lead.id']) ->
   else
     json = {}
     for field in fieldIds
-      json[field] = dotaccess.get(vars, field)
+      json[field] = dotaccess.get(vars, field)?.valueOf()
     json = flat.unflatten(json)
 
     if mimeType == 'application/xml' or mimeType == 'text/xml'

--- a/src/verbose.coffee
+++ b/src/verbose.coffee
@@ -1,0 +1,35 @@
+inbound = require('./inbound')
+flat = require('flat')
+_ = require('lodash')
+
+#
+# Response Function ------------------------------------------------------
+#
+
+response = (req, vars) ->
+
+  fieldIds = []
+  if vars.appended
+  # only send appended fields, but those need to be under an appended object to have the correct fieldId
+    appended = appended: vars.appended
+    fieldIds = _.keys(flat.flatten(appended, safe: true))
+
+  fieldIds.push('outcome', 'reason', 'lead.id')
+
+  inbound.response(req, vars, fieldIds)
+
+response.variables = ->
+  [
+    { name: 'lead.id', type: 'string', description: 'The lead identifier that the source should reference' }
+    { name: 'outcome', type: 'string', description: 'The outcome of the transaction (default is success)' }
+    { name: 'reason', type: 'string', description: 'If the outcome was a failure, this is the reason' }
+    { name: 'appended.*', type: 'wildcard'}
+  ]
+
+#
+# Exports ----------------------------------------------------------------
+#
+
+module.exports =
+  request: inbound.request
+  response: response


### PR DESCRIPTION
This is the implementation so far. It looks like [the existing `module_ids`](https://github.com/activeprospect/leadconduit-integration-default/blob/3e3c10bc13734930a1be87d919f195c63591631e/index.js) will have to be changed.