### PR TITLE
use failure/error reason text from 'message' attribute, if none in 'reason'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.7.5] - 2016-09-14
+### Fixed
+- Use failure/error reason text from 'message' attribute, if none in 'reason'
+
 ## [2.7.4] - 2016-07-20
 ### Fixed
 - Add this changelog

--- a/spec/outbound_spec.coffee
+++ b/spec/outbound_spec.coffee
@@ -184,6 +184,20 @@ describe 'Outbound Response', ->
     assert.deepEqual event, expected
 
 
+  it 'should use handler "message" as error reason', ->
+    expected =
+      outcome: 'error'
+      reason: 'Flow is disabled'
+
+    res =
+      status: 403
+      headers:
+        'Content-Type': 'application/json'
+      body: '{ "message": "Flow is disabled" }'
+
+    event = integration.response(vars, req, res)
+    assert.deepEqual event, expected
+
 
 assertMethodNotAllowed = (method) ->
   vars = variables()

--- a/src/outbound.coffee
+++ b/src/outbound.coffee
@@ -88,7 +88,7 @@ response = (vars, req, res) ->
   if !event.outcome?
     event =
       outcome: vars.default_outcome or 'error'
-      reason: event.reason or 'Unrecognized response'
+      reason: event.reason or event.message or 'Unrecognized response'
 
   event
 


### PR DESCRIPTION
Noticed this in an errored Facebook delivery, and figured this integration
should support the JSON format that LC itself emits.