### PR TITLE
Add error handling around parsing for form-encoded data [CH 579]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.8.2] - 2019-10-04
+### Fixed
+- Add error handling around parsing for form-encoded data
+
 ## [2.8.1] - 2018-12-03
 ### Added
 - Send and capture price in outbound response/request

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "dotaccess": "^1.0.5",
     "flat": "^1.3.0",
     "leadconduit-integration": "^0.1.0",
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "mime-content": ">=0.0.6",
     "mimeparse": "*",
     "xmlbuilder": "^7.0.0"
@@ -28,7 +28,7 @@
   "devDependencies": {
     "chai": ">= 1.9.0",
     "coffee-script": ">= 1.7.0",
-    "leadconduit-cakefile": "^0.3.1",
+    "leadconduit-cakefile": "^0.3.4",
     "mocha": ">= 1.17.0"
   }
 }

--- a/spec/inbound_spec.coffee
+++ b/spec/inbound_spec.coffee
@@ -53,6 +53,16 @@ describe 'Inbound Request', ->
       assert.equal e.body, 'Body does not contain XML or XML is unparseable -- Error: Non-whitespace before first tag. Line: 0 Column: 1 Char: x.'
       assert.deepEqual e.headers, 'Content-Type': 'text/plain'
 
+  it 'should throw an error when it cant parse form-encoded data', ->
+    body = 'first_name=SolarReviews&&postal_code=92014&utility=SCE&price=98&utility.electric.company.name=SCE&electric_monthly_amount_oos=150&email=Test@solarreviews123.com'
+    try
+      integration.request(method: 'post', uri: '/flows/12345/sources/12345/submit', headers: { 'Content-Length': body.length, 'Content-Type': 'application/x-www-form-urlencoded'}, body: body)
+      assert.fail("expected an error to be thrown when form-encoded content cannot be parsed")
+    catch e
+      assert.equal e.status, 400
+      assert.equal e.body, "Body does not contain form-encoded data or form-encoded data is unparseable -- TypeError: Cannot read property 'company' of undefined."
+      assert.deepEqual e.headers, 'Content-Type': 'text/plain'
+
 
    it 'should not parse empty body', ->
       req =

--- a/spec/inbound_spec.coffee
+++ b/spec/inbound_spec.coffee
@@ -60,7 +60,7 @@ describe 'Inbound Request', ->
       assert.fail("expected an error to be thrown when form-encoded content cannot be parsed")
     catch e
       assert.equal e.status, 400
-      assert.equal e.body, "Body does not contain form-encoded data or form-encoded data is unparseable -- TypeError: Cannot read property 'company' of undefined."
+      assert.equal e.body, "Unable to parse body -- TypeError: Cannot read property 'company' of undefined."
       assert.deepEqual e.headers, 'Content-Type': 'text/plain'
 
 

--- a/src/inbound.coffee
+++ b/src/inbound.coffee
@@ -81,7 +81,11 @@ request = (req) ->
 
       # if form URL encoding, convert dot notation keys
       if mimeType == 'application/x-www-form-urlencoded'
-        parsed = flat.unflatten(parsed)
+        try
+          parsed = flat.unflatten(parsed)
+        catch e
+          formEncodedError = e.toString()
+          throw new HttpError(400, {'Content-Type': 'text/plain'}, "Body does not contain form-encoded data or form-encoded data is unparseable -- #{formEncodedError}.")
 
       # if XML, turn doc into an object
       if mimeType == 'application/xml' or mimeType == 'text/xml'

--- a/src/inbound.coffee
+++ b/src/inbound.coffee
@@ -85,7 +85,7 @@ request = (req) ->
           parsed = flat.unflatten(parsed)
         catch e
           formEncodedError = e.toString()
-          throw new HttpError(400, {'Content-Type': 'text/plain'}, "Body does not contain form-encoded data or form-encoded data is unparseable -- #{formEncodedError}.")
+          throw new HttpError(400, {'Content-Type': 'text/plain'}, "Unable to parse body -- #{formEncodedError}.")
 
       # if XML, turn doc into an object
       if mimeType == 'application/xml' or mimeType == 'text/xml'


### PR DESCRIPTION
Pretty simple change, more info on the [ticket](https://app.clubhouse.io/active-prospect/story/579/improve-error-handling-for-malformed-form-encoded-data-in-the-standard-inbound-integration)