### PR TITLE
add support for xxtrustedformpingurl

### DIFF
--- a/lib/inbound.js
+++ b/lib/inbound.js
@@ -320,9 +320,19 @@ const normalizeTrustedFormCertUrl = obj =>
     const result = [];
     for (const param in obj) {
       const value = obj[param];
-      if ((param != null ? param.toLowerCase() : undefined) === 'xxtrustedformcerturl') {
-        obj.trustedform_cert_url = value;
-        result.push(delete obj[param]);
+      if (param != null) {
+        switch (param.toLowerCase()) {
+          case 'xxtrustedformcerturl':
+            obj.trustedform_cert_url = value;
+            result.push(delete obj[param]);
+            break;
+          case 'xxtrustedformpingurl':
+            obj.trustedform_ping_url = value;
+            result.push(delete obj[param]);
+            break;
+          default:
+            result.push(undefined);
+        }
       } else {
         result.push(undefined);
       }

--- a/test/inbound_spec.js
+++ b/test/inbound_spec.js
@@ -94,6 +94,11 @@ describe('Inbound Request', function () {
     assertParses('application/x-www-form-urlencoded', body, { trustedform_cert_url: 'https://cert.trustedform.com/testtoken' });
   });
 
+  it('should parse xxTrustedFormPingUrl from the request body', () => {
+    const body = 'xxTrustedFormPingUrl=https://ping.trustedform.com/testtoken';
+    assertParses('application/x-www-form-urlencoded', body, { trustedform_ping_url: 'https://ping.trustedform.com/testtoken' });
+  });
+
   it('should parse xxTrustedFormCertUrl case insensitively', () => {
     const body = 'XXTRUSTEDFORMCERTURL=https://cert.trustedform.com/testtoken';
     assertParses('application/x-www-form-urlencoded', body, { trustedform_cert_url: 'https://cert.trustedform.com/testtoken' });


### PR DESCRIPTION
## Description of the change

adds support for alternate ping url format

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/36384/normalize-trustedform-ping-urls-with-leadconduit-standard-integration

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
