### PR TITLE
add support for pings with trustedform_ping_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.9.7] - 2022-03-28
+### Fixed
+- Add support for pings with `trustedform_ping_url` ([sc-37183](https://app.shortcut.com/active-prospect/story/37183/allow-a-trustedform-ping-url-to-be-passed-in-the-trustedfrom-cert-url-field-of-trustedform-data-service-integration))
+
 ## [2.9.6] - 2022-03-11
 ### Fixed
 - Capture TrustedForm ping or cert URL into `trustedform_cert_url` ([sc-37183](https://app.shortcut.com/active-prospect/story/37183/allow-a-trustedform-ping-url-to-be-passed-in-the-trustedfrom-cert-url-field-of-trustedform-data-service-integration))

--- a/lib/inbound.js
+++ b/lib/inbound.js
@@ -320,7 +320,7 @@ const normalizeTrustedFormCertUrl = function (obj, isLcPing) {
   let certUrl, pingUrl;
   for (const param in obj) {
     const lowered = param.toLowerCase();
-    if (lowered === 'xxtrustedformpingurl') {
+    if (lowered === 'xxtrustedformpingurl' || lowered === 'trustedform_ping_url') {
       pingUrl = obj[param];
       delete obj[param];
     } else if (lowered === 'xxtrustedformcerturl') {

--- a/test/inbound_spec.js
+++ b/test/inbound_spec.js
@@ -110,6 +110,17 @@ describe('Inbound Request', function () {
     assert.equal(result.trustedform_cert_url, 'https://ping.trustedform.com/0.whatever');
   });
 
+  it('should capture TF ping URL on LC ping with snakecased parameter', () => {
+    const req = {
+      method: 'POST',
+      uri: '/flows/12345/sources/12345/ping',
+      headers: { 'Content-Length': 0, 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: 'trustedform_ping_url=https://ping.trustedform.com/0.whatever'
+    };
+    const result = integration.request(req);
+    assert.equal(result.trustedform_cert_url, 'https://ping.trustedform.com/0.whatever');
+  });
+
   it('should capture TF cert URL on LC ping with only cert URL', () => {
     const req = {
       method: 'POST',


### PR DESCRIPTION
## Description of the change

add support for pings with trustedform_ping_url

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/37183/allow-a-trustedform-ping-url-to-be-passed-in-the-trustedfrom-cert-url-field-of-trustedform-data-service-integration

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
