### PR TITLE
Sc 40370/h1 lc server side request forgery ssrf within

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.9.8] - 2022-07-06
+### Fixed
+- Fixed SSRF bug ([sc-40370](https://app.shortcut.com/active-prospect/story/40370/h1-lc-server-side-request-forgery-ssrf-within-leadconduit-standard-functionality))
+
 ## [2.9.7] - 2022-03-28
 ### Fixed
 - Add support for pings with `trustedform_ping_url` ([sc-37183](https://app.shortcut.com/active-prospect/story/37183/allow-a-trustedform-ping-url-to-be-passed-in-the-trustedfrom-cert-url-field-of-trustedform-data-service-integration))

--- a/lib/outbound.js
+++ b/lib/outbound.js
@@ -4,6 +4,11 @@ const mimeparse = require('mimeparse');
 const querystring = require('querystring');
 const flat = require('flat');
 const URL = require('url').URL;
+const isValidDomain = require('is-valid-domain');
+const ipaddr = require('ipaddr.js');
+const tlds = require('tlds');
+const isPrivateIp = require('private-ip');
+const isLocalOrTestEnv = /^(test|local)$/.test(process.env.NODE_ENV);
 
 //
 // Request Function --------------------------------------------------------
@@ -151,11 +156,24 @@ const bestMimeType = function (contentType) {
   return mimeType;
 };
 
-const isValidUrl = url =>
-  (url.protocol != null) &&
-  url.protocol.match(/^http[s]?:/) &&
-  (url.hostname != null)
-;
+const isPublic = hostname => {
+  if (ipaddr.isValid(hostname)) {
+    return !isPrivateIp(hostname); // checks both IPv4 and IPv6
+  } else {
+    const tld = hostname.split('.').pop(); // ex: "com" from hostname hello.com
+
+    return tld && tlds.includes(tld);
+  }
+};
+
+const isValidUrl = url => {
+  const baseValidation = (url.protocol != null) &&
+    url.protocol.match(/^http[s]?:/) &&
+    (url.hostname != null);
+  return isLocalOrTestEnv ? baseValidation : baseValidation &&
+    (isValidDomain(url.hostname) ||
+      ipaddr.isValid(url.hostname));
+};
 
 const validate = function (vars) {
   if ((vars.default_outcome != null) && !vars.default_outcome.match(/success|failure|error/)) {
@@ -171,6 +189,9 @@ const validate = function (vars) {
     const url = new URL(vars.url);
     if (!isValidUrl(url)) {
       return 'URL must be valid';
+    }
+    if (!isLocalOrTestEnv && !isPublic(url.hostname)) {
+      return 'URL must be public';
     }
   } catch (e) {
     return 'URL must be valid';

--- a/package.json
+++ b/package.json
@@ -20,10 +20,14 @@
   "dependencies": {
     "dotaccess": "^1.0.5",
     "flat": "^1.3.0",
+    "ipaddr.js": "^2.0.1",
+    "is-valid-domain": "^0.1.6",
     "leadconduit-integration": "^0.2.0",
     "lodash": "^4.17.15",
     "mime-content": "~0.0.8",
     "mimeparse": "^0.1.4",
+    "private-ip": "^2.3.3",
+    "tlds": "^1.231.0",
     "xmlbuilder": "^7.0.0"
   },
   "devDependencies": {

--- a/test/helper.js
+++ b/test/helper.js
@@ -11,7 +11,7 @@ module.exports = {
       override = flat.flatten(override, { safe: true });
 
       const vars = {
-        url: 'http://externalservice',
+        url: 'http://externalservice.com',
         method: 'post',
         lead: {
           first_name: 'Joe',


### PR DESCRIPTION
## Description of the change

Add logic for checking url format and whether it is public or not with exceptions for local and testing environments. Added a couple of tests.

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/40370/h1-lc-server-side-request-forgery-ssrf-within-leadconduit-standard-functionality

## Checklists

### Development and Testing

- [x]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [x]  At least one engineer has been added as "Reviewers" on the pull request.
- [x]  Changes have been reviewed by at least one other engineer who did not write the code.
- [x]  This branch has been rebased off master to be current.

### Tracking 
- [x]  Issue from Shortcut has a link to this pull request.
- [x]  This PR has a link to the issue in Shortcut.

### QA
- [x]  This branch has been deployed to staging and tested.
