### PR TITLE
fix to handle carriage-returns in bad JSON on inbound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [2.9.10] - 2023-05-17
+### Fixed
+- Fixed to also handle carriage-returns in bad JSON on inbound ([sc-57317](https://app.shortcut.com/active-prospect/story/57317/fix-default-inbound-to-handle-dos-line-breaks))
+
 ## [2.9.9] - 2023-02-07
 ### Fixed
 - Fixed to better handle bad JSON on inbound ([sc-48925](https://app.shortcut.com/active-prospect/story/48925/improve-handling-of-inbound-leads-with-bad-json))

--- a/lib/inbound.js
+++ b/lib/inbound.js
@@ -87,7 +87,7 @@ const request = function (req) {
         if(mimeType === 'application/json') {
           // a common problem with inbound JSON is when values have embedded newlines or tabs; retry without those
           try {
-            parsed = mimecontent(body.replace(/[\n\t]/g, ''), mimeType);
+            parsed = mimecontent(body.replace(/[\r\n\t]/g, ''), mimeType);
           } catch (e) {
             throw new HttpError(400, { 'Content-Type': 'text/plain' }, `Unable to parse JSON -- ${e}`);
           }

--- a/test/inbound_spec.js
+++ b/test/inbound_spec.js
@@ -104,14 +104,13 @@ describe('Inbound Request', function () {
   });
 
   it('should parse JSON with newline characters in values', () => {
-    const body = `{
-      "first_name": "Harold",
-      "address_1": "123 
-      Main St"
-    }`;
+    // newline in address_1 value, & carriage return + newline in address_2
+    const body = '{\n    "first_name": "Harold",\n    "address_1": "123 \n      Main St",\n    "address_2": "Apt.\r\n123"\n}';
+
     assertParses('application/json', body, {
       first_name: 'Harold',
-      address_1: '123       Main St'
+      address_1: '123       Main St',
+      address_2: 'Apt.123'
     });
   });
 


### PR DESCRIPTION
## Description of the change

fix to handle carriage-returns in bad JSON on inbound

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.shortcut.com/active-prospect/story/57317/fix-default-inbound-to-handle-dos-line-breaks

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [ ]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [ ]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Shortcut/Jira has a link to this pull request.
- [ ]  This PR has a link to the issue in Shortcut.

### QA
- [ ]  This branch has been deployed to staging and tested.
